### PR TITLE
Build: Use github URL instead of local path in SJSIR files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,12 @@ lazy val laminar = project.in(file("."))
       "org.scalatest" %%% "scalatest" % Versions.ScalaTest % Test,
     ),
 
-    scalacOptions ++= Seq("-deprecation", "-feature", "-language:higherKinds", "-language:implicitConversions"),
+    scalacOptions ++= {
+      val local = baseDirectory.value.toURI
+      val remote = s"https://raw.githubusercontent.com/raquo/Laminar/${git.gitHeadCommit.value.get}/"
 
+      Seq("-deprecation", "-feature", "-language:higherKinds", "-language:implicitConversions", s"-P:scalajs:mapSourceURI:$local->$remote")
+    },
     version in installJsdom := Versions.JsDom,
 
     useYarn := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.17")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
I'm fairly new to Scala.JS, so apologies if any of the below sounds flat-out wrong, if there's a good reason why a change like this doesn't make sense, or if there's a better solution you've already considered. But here's what I seem to have found:

The source URL that's included in the .sjsir seems to default to the local source path. In certain toolchains that try to include/reference library sources (in my case, that includes scalajs-bundler), this leads to persistent warnings in the webpack process along the lines of this one:

```
[warn] NonErrorEmittedError: (Emitted value instead of an instance of Error) Cannot find source file '../../../../../../../../raquo/code/scala/laminar/src/main/scala/com/raquo/laminar/DomApi.scala': Error: Can't resolve '../../../../../../../../raquo/code/scala/laminar/src/main/scala/com/raquo/laminar/DomApi.scala' in [my project directory]
```

The fix I've seen for this is to use the `mapSourceURI` compiler flag to map to the raw.githubusercontent.com URL, and that seems to change the URL in the sjsir files from a local `file:/` path to a remote one on Github.

The perhaps bigger benefit (besides fewer warnings in specific use cases) is that, with this change, I'm able to inspect library sources in the browser when I generate a source map that includes included libraries.