### PR TITLE
Update DomApi.scala

### DIFF
--- a/src/main/scala/com/raquo/laminar/DomApi.scala
+++ b/src/main/scala/com/raquo/laminar/DomApi.scala
@@ -191,7 +191,9 @@ object DomApi {
     if (domValue == null) { // End users should use `removeSvgAttribute` instead. This is to support boolean attributes.
       removeSvgAttribute(element, attr)
     } else {
-      element.ref.setAttributeNS(namespaceURI = attr.namespace.orNull, qualifiedName = attr.name, value = domValue)
+      attr.namespace.fold(element.ref.setAttribute(attr.name,domValue)){ns=>
+        element.ref.setAttributeNS(namespaceURI = ns, qualifiedName = attr.name, value = domValue)
+      }  
     }
   }
 


### PR DESCRIPTION
This change avoids `null` as a namespace in `setAttributeNS` when setting an SVG attribute. This is unsupported in at least Firefox and Edge. The error can easily be triggered by using `render(...,svg.svg(svg.xmlns:="..."))` in a ScalaFiddle.