### PR TITLE
Mdoc 2.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots") // for mdoc (see also plugins.sbt)
-
 ThisBuild / scalaVersion := Versions.Scala_2_13
 
 ThisBuild / crossScalaVersions := Seq(Versions.Scala_2_12, Versions.Scala_2_13, Versions.Scala_3)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.sonatypeRepo("snapshots") // For mdoc (see also build.sbt)
-
 logLevel := Level.Warn
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
@@ -12,7 +10,7 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24+18-e98df169-SNAPSHOT")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 


### PR DESCRIPTION
Currently Laminar is not affected by the main issue fixed in this release (because it's using SJS 1.7.0), but this should future-proof it.

Locally I've confirmed that everything works with `website/docusaurusCreateSite` and running examples on the site itself.