### PR TITLE
Add support for passive event listeners

### DIFF
--- a/src/main/scala/com/raquo/laminar/DomApi.scala
+++ b/src/main/scala/com/raquo/laminar/DomApi.scala
@@ -79,7 +79,7 @@ object DomApi {
     element.ref.addEventListener(
       `type` = EventProcessor.eventProp(listener.eventProcessor).name,
       listener = listener.domCallback,
-      useCapture = EventProcessor.shouldUseCapture(listener.eventProcessor)
+      options = listener.options
     )
   }
 
@@ -90,7 +90,7 @@ object DomApi {
     element.ref.removeEventListener(
       `type` = EventProcessor.eventProp(listener.eventProcessor).name,
       listener = listener.domCallback,
-      useCapture = EventProcessor.shouldUseCapture(listener.eventProcessor)
+      options = listener.options
     )
   }
 

--- a/src/main/scala/com/raquo/laminar/modifiers/EventListener.scala
+++ b/src/main/scala/com/raquo/laminar/modifiers/EventListener.scala
@@ -3,6 +3,7 @@ package com.raquo.laminar.modifiers
 import com.raquo.airstream.ownership.{DynamicSubscription, Subscription}
 import com.raquo.laminar.DomApi
 import com.raquo.laminar.keys.EventProcessor
+import com.raquo.laminar.keys.EventProcessor.{shouldUseCapture, shouldBePassive}
 import com.raquo.laminar.lifecycle.MountContext
 import com.raquo.laminar.nodes.ReactiveElement
 import org.scalajs.dom
@@ -28,6 +29,11 @@ class EventListener[Ev <: dom.Event, Out](
 
   @deprecated("Renamed: Use `domCallback` instead of `domValue`", "0.12.0")
   val domValue: js.Function1[Ev, Unit] = domCallback
+
+  val options: dom.EventListenerOptions = new dom.EventListenerOptions {
+    capture = shouldUseCapture(eventProcessor)
+    passive = shouldBePassive(eventProcessor)
+  }
 
   override def bind(element: ReactiveElement.Base): DynamicSubscription = {
     bind(element, unsafePrepend = false)


### PR DESCRIPTION
This PR adds support for registering event listeners as passive. For some types of events, e.g. scroll events, this can make a substantial difference in performance and responsiveness.