### PR TITLE
Testing with chrome using scala-js-env-playwright with esmodules and …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val website = project
   )
 
 lazy val laminar = project.in(file("."))
-  .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
+  .enablePlugins(ScalaJSPlugin)
   .settings(
     libraryDependencies ++= Seq(
       "com.raquo" %%% "airstream" % Versions.Airstream,
@@ -135,17 +135,16 @@ lazy val laminar = project.in(file("."))
       "-no-link-warnings" // Suppress scaladoc "Could not find any member to link for" warnings
     ),
 
-    (Test / parallelExecution) := false,
+    (Test / parallelExecution) := true,
 
-    (Test / requireJsDomEnv) := true,
-
-    (installJsdom / version) := Versions.JsDom,
-
-    (webpack / version) := Versions.Webpack,
-
-    (startWebpackDevServer / version) := Versions.WebpackDevServer,
-
-    useYarn := true,
+    jsEnv := new jsenv.playwright.PWEnv(
+      browserName = "chromium",
+      headless = true,
+      showLogs = false
+    ),
+    scalaJSLinkerConfig ~= {
+      _.withModuleKind(ModuleKind.ESModule)
+    },
 
     scalaJSUseMainModuleInitializer := true,
 
@@ -174,6 +173,7 @@ lazy val laminar = project.in(file("."))
       )
     ),
     (Test / publishArtifact) := false,
+    Test / scalaJSStage := FullOptStage,
     pomIncludeRepository := { _ => false },
     sonatypeCredentialHost := "s01.oss.sonatype.org",
     sonatypeRepository := "https://s01.oss.sonatype.org/service/local"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.11"
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")

--- a/src/test/scala/com/raquo/laminar/StyleReceiverSpec.scala
+++ b/src/test/scala/com/raquo/laminar/StyleReceiverSpec.scala
@@ -125,13 +125,13 @@ class StyleReceiverSpec extends UnitSpec {
     expectNode(div.of(backgroundImage is "", "Yo"))
 
     urlBus.emit(url1)
-    expectNode(div.of(backgroundImage is "url(/example.png)", "Yo"))
+    expectNode(div.of(backgroundImage is "url(\"/example.png\")", "Yo"))
 
     urlBus.emit(url2)
-    expectNode(div.of(backgroundImage is "url(https://example.com)", "Yo"))
+    expectNode(div.of(backgroundImage is "url(\"https://example.com\")", "Yo"))
 
     urlBus.emit(url3)
-    expectNode(div.of(backgroundImage is "url(foo.jpg)", "Yo"))
+    expectNode(div.of(backgroundImage is "url(\"foo.jpg\")", "Yo"))
   }
 
 }

--- a/src/test/scala/com/raquo/laminar/basic/StyleSpec.scala
+++ b/src/test/scala/com/raquo/laminar/basic/StyleSpec.scala
@@ -80,7 +80,7 @@ class StyleSpec extends UnitSpec {
     ))
     expectNode(
       span.of(
-        backgroundImage is """url(example.jpg)"""
+        backgroundImage is """url("example.jpg")"""
       )
     )
     unmount()


### PR DESCRIPTION
[scala-js-env-playwright](https://github.com/gmkumar2005/scala-js-env-playwright) is an independent project that offers a JSEnv that uses Playwright for JavaScript execution. 
This PR enables testing with chrome browser. 
Laminar is most likely to be used with `fastLinkJS` and `ESModule` hence testing with these setting enabled will help identify errors in real browsers.
In the latest edition allows you to verify the actual version of the browser being used. `debug = true` to the PWEnv 
```scala 
 jsEnv := new jsenv.playwright.PWEnv(
      browserName = "chromium",
      headless = true,
      debug = true
    ),
```