### PR TITLE
Use lazy arguments for when and whenNot

### DIFF
--- a/src/main/scala/com/raquo/laminar/api/Laminar.scala
+++ b/src/main/scala/com/raquo/laminar/api/Laminar.scala
@@ -195,7 +195,7 @@ trait Laminar
 
 
   /** Modifier that applies one or more modifiers if `condition` is true */
-  def when[El <: Element](condition: Boolean)(mods: Modifier[El]*): Modifier[El] = {
+  def when[El <: Element](condition: Boolean)(mods: => Modifier[El]*): Modifier[El] = {
     if (condition) {
       mods // implicitly converted to a single modifier
     } else {
@@ -204,7 +204,7 @@ trait Laminar
   }
 
   /** Modifier that applies one or more modifiers if `condition` is true */
-  @inline def whenNot[El <: Element](condition: Boolean)(mods: Modifier[El]*): Modifier[El] = when(!condition)(mods)
+  @inline def whenNot[El <: Element](condition: Boolean)(mods: => Modifier[El]*): Modifier[El] = when(!condition)(mods)
 
 
   /** Creates controlled input block.


### PR DESCRIPTION
Hi, here is a small change/fix.

When using `when` as a shortcut for an `if`, it violated my assumption that the conditional code would not be executed at all. Instead, it is executed but its result not used. Not a problem if your code is mostly pure, but if there are lurking some side effects, it can give you a hard time finding the problem. _I did set the boolean correctly, did I?_

I suggest to use lazy parameters here, which makes usage of `when` as equivalent to `ìf` as possible.